### PR TITLE
ホームページのボタン活性化タイミング変更

### DIFF
--- a/frontend/front/src/Unity/Unity.jsx
+++ b/frontend/front/src/Unity/Unity.jsx
@@ -64,6 +64,14 @@ export function Avatar() {
   const { unityProvider, sendMessage, addEventListener, removeEventListener } = GetUnityFunctions();
 
   const text = AvatarText();
+  const [disabled, setDisabled] = useState(true);
+  const [disabledStyle, setDisabledStyle] = useState({ opacity: 0.6, cursor: "wait" });
+  setTimeout(
+    () => {
+      setDisabled(false);
+      setDisabledStyle({ opacity: 1, cursor: "pointer" });
+    },
+    7000);
   return (
     <Fragment>
       <div className="Avatar">
@@ -81,7 +89,7 @@ export function Avatar() {
         <button id="HiddenButton">hidden</button>
         <div className="sendText">
           <textarea placeholder="アバターへのメッセージを入力してください。" value={sendText} onChange={handleChangeSendText} />
-          <button className="sendTextButton" onClick={() => sendTextToAvatar(sendText)}>send</button>
+          <button className="sendTextButton" onClick={() => sendTextToAvatar(sendText)} disabled={disabled} style={disabledStyle}>send</button>
         </div>
         <div className="AvatarText"><p>{`${text}`}</p></div>
         <Unity unityProvider={unityProvider} className="AvatarCanvas" />

--- a/frontend/front/src/components/SwitchDisable.jsx
+++ b/frontend/front/src/components/SwitchDisable.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 
 export const SwitchDisable = () => {
     const [disable, setDisable] = useState(true);
-    const [disableStyle, setDisableStyle] = useState({ opacity: 0.6 })
+    const [disableStyle, setDisableStyle] = useState({ opacity: 0.6, cursor: "wait" })
     useEffect(() => {
     }, [])
     const startTime = ManageDisplyButton().startTime;
@@ -12,7 +12,7 @@ export const SwitchDisable = () => {
         if (startTime !== "") {
             setTimeout(() => {
                 setDisable(false)
-                setDisableStyle({ opacity: 1 })
+                setDisableStyle({ opacity: 1, cursor: "pointer" })
             }, interval)
         }
     }, [startTime])

--- a/frontend/front/src/page/Home.jsx
+++ b/frontend/front/src/page/Home.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 // import StartButton from "../components/StartButton";
 // import SetButton from "../components/SetButton";
@@ -6,13 +6,22 @@ import Button from "../components/Button";
 import "./css/Home.css";
 
 function Home() {
+  const [disabled, setDisabled] = useState(true);
+  const [disabledStyle, setDisabledStyle] = useState({ opacity: 0.6, cursor: "wait" });
+  const [subTitle, setSubTitle] = useState("バーチャルガイドと接続中です")
+  setTimeout(
+    () => {
+      setDisabled(false);
+      setDisabledStyle({ opacity: 1, cursor: "pointer" });
+      setSubTitle("～旅するバーチャルガイド～");
+    },
+    7000);
 
   return (
     <div className="home">
       <h1>TabitaRO</h1>
-      {/* <StartButton />
-      <SetButton /> */}
-      <Button to="/setting" label="start" hiddenButtonId={"settingHiddenButton"} />
+      <h2>{subTitle}</h2>
+      <Button to="/setting" label="start" hiddenButtonId={"settingHiddenButton"} disable={disabled} style={disabledStyle} />
     </div>
   );
 }

--- a/frontend/front/src/page/css/Home.css
+++ b/frontend/front/src/page/css/Home.css
@@ -8,6 +8,12 @@
 .home h1 {
     margin-top: 40vh;
     font-size: 2.8em;
+    margin-bottom: 0;
+}
+
+.home h2 {
+    margin-top: 0;
+    margin-bottom: 10vh;
 }
 
 .wrap {


### PR DESCRIPTION
# ホームページのボタン活性化タイミング変更
ホームページにあるボタンをユーザが押せるようになるタイミングをunityの起動に合わせるように変更した

## なぜこの変更をするのか
unityが起動する前に画面を操作できるようになっていたから

## やったこと
* [x] startボタンをアクセス後7秒後に活性化
* [x] sendボタンをアクセス後7秒後に活性化
* [x] 非活性化のときはボタンにホバーすると、カーソルがローディングに変更

## 変更内容
* 非活性化のとき：ボタン半透明、カーソル：ローディング
* 活性化のとき：ボタン透明なし、カーソル：ポインター