### PR TITLE
デザイン変更

### DIFF
--- a/frontend/front/public/index.html
+++ b/frontend/front/public/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
-  <meta name="description" content="Web site created using create-react-app" />
+  <meta name="description" content="旅するバーチャルガイド" />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
 
 
@@ -16,7 +16,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;800&display=swap" rel="stylesheet">
 
-  <title>React App</title>
+  <title>TabiTaRO</title>
 </head>
 
 <body>

--- a/frontend/front/src/Unity/Unity.css
+++ b/frontend/front/src/Unity/Unity.css
@@ -1,5 +1,5 @@
 .Avatar {
-    height: 99vh;
+    height: 93vh;
     width: 42vw;
     display: flex;
     flex-flow: column;

--- a/frontend/front/src/Unity/Unity.css
+++ b/frontend/front/src/Unity/Unity.css
@@ -1,5 +1,5 @@
 .Avatar {
-    height: 93vh;
+    height: 92vh;
     width: 42vw;
     display: flex;
     flex-flow: column;

--- a/frontend/front/src/Unity/Unity.jsx
+++ b/frontend/front/src/Unity/Unity.jsx
@@ -22,6 +22,9 @@ export function Avatar() {
   let sendArrivePlace1;
   let sendArrivePlace2;
   let sendArrivePlace3;
+  if (name != "taro") {
+    username = String(name);
+  }
   if (coordinate != "init") {
     relationship = String(rel);
     username = String(name);

--- a/frontend/front/src/components/Map.jsx
+++ b/frontend/front/src/components/Map.jsx
@@ -11,7 +11,7 @@ const Map = () => {
 
   const container = {
     width: "75%",
-    height: "500px",
+    height: "70vh",
   };
 
   const defaultPosition = {

--- a/frontend/front/src/index.css
+++ b/frontend/front/src/index.css
@@ -113,5 +113,3 @@ footer {
   text-align: center;
   justify-content: center;
 }
-
-footer span {}

--- a/frontend/front/src/index.css
+++ b/frontend/front/src/index.css
@@ -1,6 +1,6 @@
 /*観光画面*/
 .App {
-  height: 99vh;
+  height: 93vh;
   width: 52vw;
   overflow-y: scroll;
   padding-right: 10px;
@@ -86,6 +86,7 @@ button:hover {
   display: flex;
   justify-content: space-around;
   overflow: hidden;
+  margin-top: 5px;
   /* min-height: 100vh; */
 }
 
@@ -100,3 +101,17 @@ button:hover {
   justify-content: space-around;
   /* flex-grow: 1; 利用可能なスペースを埋める */
 }
+
+/* クレジット表記 */
+footer {
+  height: 7vh;
+  width: 94vw;
+  position: absolute;
+  bottom: 0;
+  font-size: 15px;
+  display: flex;
+  text-align: center;
+  justify-content: center;
+}
+
+footer span {}

--- a/frontend/front/src/index.css
+++ b/frontend/front/src/index.css
@@ -1,6 +1,6 @@
 /*観光画面*/
 .App {
-  height: 93vh;
+  height: 92vh;
   width: 52vw;
   overflow-y: scroll;
   padding-right: 10px;
@@ -63,7 +63,7 @@ button:hover {
 .next_button_parent {
   width: 52vw;
   position: absolute;
-  bottom: 2px;
+  bottom: 50px;
 }
 
 .next_button_parent button {
@@ -104,12 +104,23 @@ button:hover {
 
 /* クレジット表記 */
 footer {
-  height: 7vh;
-  width: 94vw;
+  height: 45px;
+  width: 100%;
   position: absolute;
   bottom: 0;
   font-size: 15px;
   display: flex;
   text-align: center;
-  justify-content: center;
+  justify-content: space-evenly;
+  background-color: #0e172c;
+  border-radius: 0%;
+}
+
+footer div {
+  display: flex;
+}
+
+footer * {
+  color: #fffffe;
+  opacity: 0.9;
 }

--- a/frontend/front/src/index.css
+++ b/frontend/front/src/index.css
@@ -3,6 +3,7 @@
   height: 99vh;
   width: 52vw;
   overflow-y: scroll;
+  padding-right: 10px;
 }
 
 .plan :hover {

--- a/frontend/front/src/index.jsx
+++ b/frontend/front/src/index.jsx
@@ -18,7 +18,7 @@ root.render(
         <footer>
           <span style={{ margin: "15px 15px 15px 15px" }}>
             <a href="https://developer.yahoo.co.jp/sitemap/">
-              Webサービス by Yahoo! JAPAN
+              Web Services by Yahoo! JAPAN
             </a>
           </span>
         </footer>

--- a/frontend/front/src/index.jsx
+++ b/frontend/front/src/index.jsx
@@ -15,19 +15,31 @@ root.render(
           <App />
           <Avatar />
         </div>
-        <footer>
+      </div>
+      <footer>
+        <div>
           <span style={{ margin: "15px 15px 15px 15px" }}>
-            <a href="https://tsumugi-official.studio.site/top">
-              VOICEVOX:春日部つむぎ
+            &copy; 2023 Team TaRO
+          </span>
+          <span style={{ margin: "15px 15px 15px 15px" }}>
+            <a href="https://github.com/abhrs0622/TaRO">
+              GitHub
             </a>
           </span>
+        </div>
+        <div>
           <span style={{ margin: "15px 15px 15px 15px" }}>
             <a href="https://developer.yahoo.co.jp/sitemap/">
               Web Services by Yahoo! JAPAN
             </a>
           </span>
-        </footer>
-      </div>
+          <span style={{ margin: "15px 15px 15px 15px" }}>
+            <a href="https://tsumugi-official.studio.site/top">
+              VOICEVOX:春日部つむぎ
+            </a>
+          </span>
+        </div>
+      </footer>
     </Provider>
   </React.StrictMode>
 );

--- a/frontend/front/src/index.jsx
+++ b/frontend/front/src/index.jsx
@@ -17,6 +17,11 @@ root.render(
         </div>
         <footer>
           <span style={{ margin: "15px 15px 15px 15px" }}>
+            <a href="https://tsumugi-official.studio.site/top">
+              VOICEVOX:春日部つむぎ
+            </a>
+          </span>
+          <span style={{ margin: "15px 15px 15px 15px" }}>
             <a href="https://developer.yahoo.co.jp/sitemap/">
               Web Services by Yahoo! JAPAN
             </a>

--- a/frontend/front/src/page/Destination.jsx
+++ b/frontend/front/src/page/Destination.jsx
@@ -5,8 +5,18 @@ import "./css/Destination.css";
 import { SwitchDisable } from "../components/SwitchDisable";
 
 const Destination = () => {
-  const disable = SwitchDisable().disable;
-  const disableStyle = SwitchDisable().disableStyle;
+  let disable = SwitchDisable().disable;
+  let disableStyle = SwitchDisable().disableStyle;
+  const perfEntries = performance.getEntriesByType("navigation");
+
+  perfEntries.forEach(function (pe) {
+    /** 読み込みタイプを取得 */
+    const type = pe.type;
+    if (type == "reload" || type == "back_forward") {
+      disable = false;
+      disableStyle = { opacity: 1 }
+    }
+  });
   return (
     <div className="Destination">
       <div className="map">

--- a/frontend/front/src/page/Sightseeing.jsx
+++ b/frontend/front/src/page/Sightseeing.jsx
@@ -42,10 +42,12 @@ const Sightseeing = () => {
     <div>
       <div
         style={{
-          width: "800px",
-          height: "450px",
+          width: "100%",
+          height: "60vh",
           backgroundColor: "000000",
+          marginTop: "60px",
         }}
+
       >
         <ReactStreetview
           apiKey={googleMapsApiKey}

--- a/frontend/front/src/page/css/Destination.css
+++ b/frontend/front/src/page/css/Destination.css
@@ -1,4 +1,4 @@
 .Destination .map {
-    margin-top: 40px;
-    margin-bottom: 30px;
+    margin-top: 20px;
+    margin-bottom: 20px;
 }

--- a/frontend/front/src/page/css/setting.css
+++ b/frontend/front/src/page/css/setting.css
@@ -1,6 +1,6 @@
 /*setting*/
 .setting {
-    height: 88%;
+    height: 80%;
     display: flex;
     flex-flow: column;
     margin: 15px 0 15px 0;

--- a/frontend/front/src/page/setting.jsx
+++ b/frontend/front/src/page/setting.jsx
@@ -58,9 +58,19 @@ const Setting = () => {
     return <ApiPost url={url} requestData={requestData} />;
   };
 
-  const disable = SwitchDisable().disable;
-  const disableStyle = SwitchDisable().disableStyle;
-  console.log("switch Disable:" + disable + disableStyle)
+  let disable = SwitchDisable().disable;
+  let disableStyle = SwitchDisable().disableStyle;
+
+  const perfEntries = performance.getEntriesByType("navigation");
+
+  perfEntries.forEach(function (pe) {
+    /** 読み込みタイプを取得 */
+    const type = pe.type;
+    if (type == "reload" || type == "back_forward") {
+      disable = false;
+      disableStyle = { opacity: 1 }
+    }
+  });
 
   return (
     <>


### PR DESCRIPTION
# ストリートビューページのcss/リロード時のボタン活性化/フッター変更/情報変更

1. ストリートビューページのデザイン変更
2. settingページ/Destinationページでリロード/バック/フォワードボタン時の動き変更
3. フッターの変更
4. タイトル/説明の変更

## なぜこの変更をするのか
1. ストリートビューページだけ新しいCSSを当ててなかった
2. ナビゲート以外でページに来るとボタンが押せなくなる
3. スクロールしないのフッターが見えなくなっていた
4. アプリケーションのタイトル/説明がデフォルトのままになっていた

## やったこと
* [x] ストリートビューをページの中央あたりに配置
* [x] settingページ/Destinationページでリロード/バック/フォワードボタンが押されたら、nextボタンを最初から活性化させる
* [x] フッターを画面内に収める
* [x] 使ったシステムのクレジット表記
* [x] コピーライト表記
* [x] アプリケーションのタイトル → TabiTaRO
* [x] アプリケーションの説明 → 旅するバーチャルガイド

## 変更内容
![home画面](https://github.com/abhrs0622/TaRO/assets/103473179/d6215db6-c297-4675-83da-5d255ea564fa)

## 影響範囲
* リロード/バック/フォワードボタンを押したとき
* settingページ
* Destinationページ

## 課題
* [ ] settingページ/Destinationページ以外はリロードしたらボタン以外の動きもおかしくなるから、リロード時の動作を決めていない
    * リロード時にalertとかで警告した方がいいかも
* [ ] Unityにユーザの名前が渡されていない気がする
    * Unity.jsxを変更してみたけど合ってるか不安

